### PR TITLE
minor mode hook and new grails-projectile-on

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,7 +25,12 @@ This project provides useful [[http://grails.org][Grails]] support for Emacs in 
 
 It is recommended to use the [[http://www.emacswiki.org/emacs/ELPA][package system]] to install dependencies.
 You'll likely want to start with =groovy-mode=.
+** Set-up
+After installation, add 
+=(require 'grails-projectile-mode)=
+=(add-hook 'projectile-mode-hook 'grails-projectile-on)=
 
+to automatically enable this minor mode.
 ** Projectile
 [[https://github.com/bbatsov/projectile/][Projectile]] is a nice way to manage projects in Emacs.
 =M-x package-install projectile [RET]=

--- a/grails-projectile-mode.el
+++ b/grails-projectile-mode.el
@@ -135,7 +135,23 @@
   :type 'string
   :group 'grails-projectile)
 
+;;;###autoload
+(defcustom grails-projectile-mode-hook nil
+  "*Hook called by `grails-projectile-mode'."
+  :type 'hook
+  :group 'projectile)
+
 ;;;_. Utilities
+(defun grails-projectile-root ()
+  "Returns grails root directory if this file is in a Grails project"
+  (let ((grails-project-root (projectile-project-root)))
+    (when (file-exists-p (expand-file-name "grails-app" grails-project-root))
+      grails-project-root)))
+
+(defun grails--ignore-buffer-p ()
+  "Returns t if `grails-projectile-mode' should not be enabled for the current buffer"
+  (string-match-p "\\*\\(Minibuf-[0-9]+\\|helm mini\\)\\*" (buffer-name)))
+
 (defun grails--join-lines (beg end)
   "Apply join-line over region."
   (interactive "r")
@@ -624,9 +640,14 @@
   grails-projectile-mode
   grails-projectile-on)
 
+;;;###autoload
 (defun grails-projectile-on ()
-  "Enable Grails Projectile minor mode."
-  (grails-projectile-mode 1))
+  "Enable `grails-projectile-mode' minor mode if this is a grails project."
+  (ignore-errors ;; ignore errors at startup if not in project
+    (when (and 
+	   (not (grails--ignore-buffer-p))
+	   (grails-projectile-root))
+      (grails-projectile-mode 1))))
 
 (defun grails-projectile-off ()
   "Disable Grails Projectile minor mode."


### PR DESCRIPTION
Hey there, 

Thanks for putting this on MELPA!

I added a minor mode hook that can be customized.  For me, this allows the loading of some grails yasnippets only when grails-projectile-mode is loaded, but I'm sure there could be other uses for this. :smile: 

I drew heavily from [projectile-rails](https://github.com/asok/projectile-rails/blob/master/projectile-rails.el) and added a `grails-projectile-root` that returns the root string if in a grails application.

This lets you establish the minor mode with 

``` lisp
(add-hook 'projectile-mode-hook 'grails-projectile-on)
```

I also borrowed the code to disable grails in helm mini buffers.

You can still use global mode, but now this just turns on when you go to the project and projectile looks at it.

Great work, and again thanks for this. :+1: :+1: 
