### PR TITLE
No jvm opts and no cmd opts by default

### DIFF
--- a/grails-projectile-config.el
+++ b/grails-projectile-config.el
@@ -61,7 +61,7 @@
   :type 'string
   :group 'grails-projectile)
 
-(defcustom grails-projectile-cmd-opts "--non-interactive --stacktrace"
+(defcustom grails-projectile-cmd-opts "--stacktrace"
   "Grails command line options."
   :type 'string
   :group 'grails-projectile)

--- a/grails-projectile-config.el
+++ b/grails-projectile-config.el
@@ -61,7 +61,7 @@
   :type 'string
   :group 'grails-projectile)
 
-(defcustom grails-projectile-cmd-opts "--stacktrace"
+(defcustom grails-projectile-cmd-opts ""
   "Grails command line options."
   :type 'string
   :group 'grails-projectile)
@@ -75,7 +75,7 @@
   :type 'string
   :group 'grails-projectile)
 
-(defcustom grails-projectile-jvm-opts "-DXmx1g"
+(defcustom grails-projectile-jvm-opts ""
   "Grails command line options"
   :type 'string
   :group 'grails-projectile)


### PR DESCRIPTION
## Problematic
- When we specif any argument except run-app, grails goes interactive mode. The temporary workaround I found was to disable all options.

```
(setq grails-projectile-cmd-opts "")
(setq grails-projectile-jvm-opts "")
```

I use grails 3.1.1 but had the same bug with 3.1.2(I tried downgrading just to be sure it wasn't grails).
